### PR TITLE
A new TypeScript file `response-wraper.type.ts` has been created, whi…

### DIFF
--- a/src/types/response-wraper.type.ts
+++ b/src/types/response-wraper.type.ts
@@ -1,0 +1,8 @@
+type ResponseWraper<
+  Data = Record<string, unknown>,
+  Field extends string | undefined = undefined,
+> =
+  | ({ success: true } & Data)
+  | { success: false; message: string; field?: Field };
+
+export default ResponseWraper;


### PR DESCRIPTION
…ch defines the following:

1. **ResponseWrapper**: A generic type that represents the structure of a response. It can be either:
   - A successful response with the `success: true` flag and additional data of type `Data` (defaulting to an empty object).
   - A failure response with the `success: false` flag, a `message` string, and an optional `field` of type `Field` (which is a string or `undefined`).

The `ResponseWraper` type is exported as the default export.