### PR TITLE
Add deployment script for production server

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,19 @@
+server="promodoro"
+folder="~/promodoro"
+image="promodoro-web-prod"
+
+pushd build || exit
+docker compose build
+docker save $image -o $image.tar
+scp $image.tar $server:$folder
+rm $image.tar
+popd || exit
+
+ssh $server <<EOF
+cd $folder
+docker compose down
+docker system prune -af
+docker load -i $image.tar
+docker compose up -d
+rm $image.tar
+EOF


### PR DESCRIPTION
- Introduced `deploy.sh` to automate build and deployment of the production Docker image.
- Builds and saves the `promodoro-web-prod` image locally.
- Transfers the image to a remote server using `scp`.
- Performs a remote redeploy using `docker compose`, pruning old containers and images.